### PR TITLE
Tag Sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .discourse-site
 node_modules
 HELP
+.history

--- a/javascripts/discourse/components/category-sidebar.gjs
+++ b/javascripts/discourse/components/category-sidebar.gjs
@@ -117,7 +117,7 @@ export default class CategorySidebar extends Component {
     } else if (this.isTagRouteAndEnabled && this.currentTag && this.parsedSetting[this.currentTag]) {
       // If the current route is a tag and there's a setting for it, use that
       return this.parsedSetting[this.currentTag];
-    } 
+    }
   }
 
   @action

--- a/javascripts/discourse/components/category-sidebar.gjs
+++ b/javascripts/discourse/components/category-sidebar.gjs
@@ -69,6 +69,19 @@ export default class CategorySidebar extends Component {
     return filteredTargets.includes(this.router.currentRouteName);
   }
 
+  get isTagRouteAndEnabled() {
+    return this.router.currentURL.includes('/tag/') && this.siteSettings.enable_for_tags;
+}
+
+  get currentTag() {
+    if (this.isTagRouteAndEnabled) {
+      const paths = this.router.currentURL.split('/');
+      const tagIndex = paths.findIndex(path => path === "tag") + 1;
+      return paths[tagIndex];
+    }
+    return null;
+  }
+
   get categorySlugPathWithID() {
     return this.router?.currentRoute?.params?.category_slug_path_with_id;
   }
@@ -101,7 +114,10 @@ export default class CategorySidebar extends Component {
       ) {
         return this.parsedSetting[parentCategorySlug];
       }
-    }
+    } else if (this.isTagRouteAndEnabled && this.currentTag && this.parsedSetting[this.currentTag]) {
+      // If the current route is a tag and there's a setting for it, use that
+      return this.parsedSetting[this.currentTag];
+    } 
   }
 
   @action

--- a/javascripts/discourse/components/category-sidebar.gjs
+++ b/javascripts/discourse/components/category-sidebar.gjs
@@ -71,7 +71,7 @@ export default class CategorySidebar extends Component {
 
   get isTagRouteAndEnabled() {
     return this.router.currentURL.includes('/tag/') && this.siteSettings.enable_for_tags;
-}
+  }
 
   get currentTag() {
     if (this.isTagRouteAndEnabled) {

--- a/javascripts/discourse/components/category-sidebar.gjs
+++ b/javascripts/discourse/components/category-sidebar.gjs
@@ -70,13 +70,16 @@ export default class CategorySidebar extends Component {
   }
 
   get isTagRouteAndEnabled() {
-    return this.router.currentURL.includes('/tag/') && this.siteSettings.enable_for_tags;
+    return (
+      this.router.currentURL.includes("/tag/") &&
+      this.siteSettings.enable_for_tags
+    );
   }
 
   get currentTag() {
     if (this.isTagRouteAndEnabled) {
-      const paths = this.router.currentURL.split('/');
-      const tagIndex = paths.findIndex(path => path === "tag") + 1;
+      const paths = this.router.currentURL.split("/");
+      const tagIndex = paths.findIndex((path) => path === "tag") + 1;
       return paths[tagIndex];
     }
     return null;
@@ -114,7 +117,11 @@ export default class CategorySidebar extends Component {
       ) {
         return this.parsedSetting[parentCategorySlug];
       }
-    } else if (this.isTagRouteAndEnabled && this.currentTag && this.parsedSetting[this.currentTag]) {
+    } else if (
+      this.isTagRouteAndEnabled &&
+      this.currentTag &&
+      this.parsedSetting[this.currentTag]
+    ) {
       // If the current route is a tag and there's a setting for it, use that
       return this.parsedSetting[this.currentTag];
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "discourse-category-tag-sidebars",
+  "name": "discourse-category-sidebars",
   "version": "0.0.2",
-  "repository": "https://github.com/mongodb-forks/discourse-category-sidebars",
+  "repository": "https://github.com/discourse/discourse-category-sidebars",
   "author": "Discourse",
   "license": "MIT",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "discourse-category-sidebars",
+  "name": "discourse-category-tag-sidebars",
   "version": "0.0.2",
-  "repository": "https://github.com/discourse/discourse-category-sidebars",
+  "repository": "https://github.com/mongodb-forks/discourse-category-sidebars",
   "author": "Discourse",
   "license": "MIT",
   "devDependencies": {

--- a/settings.yml
+++ b/settings.yml
@@ -14,3 +14,8 @@ inherit_parent_sidebar:
 
 stick_on_scroll:
   default: true
+  
+enable_for_tags:
+  default: true
+  description: |
+    Enable this component for tag pages: /tag/<b>tagname</b> 

--- a/settings.yml
+++ b/settings.yml
@@ -14,8 +14,8 @@ inherit_parent_sidebar:
 
 stick_on_scroll:
   default: true
-  
+
 enable_for_tags:
   default: true
   description: |
-    Enable this component for tag pages: /tag/<b>tagname</b> 
+    Enable this component for tag pages: /tag/<b>tagname</b>


### PR DESCRIPTION
Had to refactor the newly updated category sidebar app. Made this new branch: `tag-sidebar-20240227` due to the plentiful changes since (2 years ago). Will retire [tag-sidebar](https://github.com/discourse/discourse-category-sidebars/compare/main...mongodb-forks:discourse-category-sidebars:tag-sidebar) branch (the one that's working on 3.1.4) once we've moved this to prod