### PR TITLE
added tag-sidebar functionality

### DIFF
--- a/javascripts/discourse/components/category-sidebar.gjs
+++ b/javascripts/discourse/components/category-sidebar.gjs
@@ -69,6 +69,22 @@ export default class CategorySidebar extends Component {
     return filteredTargets.includes(this.router.currentRouteName);
   }
 
+  get isTagRouteAndEnabled() {
+    return (
+      this.router.currentURL.includes("/tag/") &&
+      this.siteSettings.enable_for_tags
+    );
+  }
+
+  get currentTag() {
+    if (this.isTagRouteAndEnabled) {
+      const paths = this.router.currentURL.split("/");
+      const tagIndex = paths.findIndex((path) => path === "tag") + 1;
+      return paths[tagIndex];
+    }
+    return null;
+  }
+
   get categorySlugPathWithID() {
     return this.router?.currentRoute?.params?.category_slug_path_with_id;
   }
@@ -101,6 +117,13 @@ export default class CategorySidebar extends Component {
       ) {
         return this.parsedSetting[parentCategorySlug];
       }
+    } else if (
+      this.isTagRouteAndEnabled &&
+      this.currentTag &&
+      this.parsedSetting[this.currentTag]
+    ) {
+      // If the current route is a tag and there's a setting for it, use that
+      return this.parsedSetting[this.currentTag];
     }
   }
 

--- a/settings.yml
+++ b/settings.yml
@@ -14,3 +14,8 @@ inherit_parent_sidebar:
 
 stick_on_scroll:
   default: true
+
+enable_for_tags:
+  default: true
+  description: |
+    Enable this component for tag pages: /tag/<b>tagname</b>


### PR DESCRIPTION
Had to refactor the newly updated category sidebar app. Made this new branch: `tag-sidebar-20240227` due to the plentiful changes since (2 years ago). Will retire [tag-sidebar](https://github.com/discourse/discourse-category-sidebars/compare/main...mongodb-forks:discourse-category-sidebars:tag-sidebar) branch (the one that's working on 3.1.4) once we've moved this to prod